### PR TITLE
Add Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 *.DS_Store
+.vscode
+vm/SDL2.dll

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Dependencies:
 - The [Rust toolchain](https://www.rust-lang.org/tools/install)
 - The [SDL2 libraries](https://wiki.libsdl.org/SDL2/Installation)
 
-To install SDL2 on MacOS:
+### To install SDL2 on MacOS:
 ```
 brew install sdl2
 ```
@@ -57,7 +57,7 @@ On MacOS, add this to `~/.zprofile`:
 export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib"
 ```
 
-To install SDL2 on Debian/Ubuntu
+### To install SDL2 on Debian/Ubuntu:
 ```
 sudo apt-get install libsdl2-dev
 ```
@@ -67,7 +67,14 @@ Install the Rust toolchain:
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-Compile the project:
+### To install SDL2 on Windows:
+
+[Install the Rust toolchain](https://www.rust-lang.org/tools/install)
+
+Get SDL2.dll from one of [SDL2 Releases](https://github.com/libsdl-org/SDL/releases)
+Copy `SDL2.dll` (unzip) to the `vm/` folder
+
+### Compile the project:
 ```
 cd vm
 cargo build
@@ -77,6 +84,9 @@ To run the compiled UVM binary:
 ```
 cargo run <input_file>
 ```
+
+### To run the test suite:
+Run `cargo test` in `vm`, `ncc` and `test` directories
 
 ## Codebase Organization
 

--- a/ncc/src/cpp.rs
+++ b/ncc/src/cpp.rs
@@ -515,7 +515,11 @@ fn process_input_rec(
                 output += &format!("{}", input.line_no);
             }
             else if ident == "__FILE__" {
-                output += &format!("\"{}\"", input.src_name);
+                let mut filename: String = format!("\"{}\"", input.src_name);
+                if cfg!(windows) {
+                    filename = str::replace(&filename, "\\", "/");
+                }
+                output += &filename;
             }
             else
             {


### PR DESCRIPTION
All tests pass now on Windows for all sub-projects.  I also added instructions on getting this working on Windows.

There was only an issue with paths in the C compiler (resulting in strings with incorrect escapes e.g. "examples\attackers").  I kept the fix as simple as possible, there are more comprehensive solutions involving std::path::{Path, components, MAIN_SEPARATOR}.

If ease of use and on-boarding is a goal (maybe not, at this early stage), you may consider including a copy of SDL.dll.  I did not include it in the PR, since a binary blob would (and should) raise security concerns, but I wrote some instructions on how to fetch it and where to put it (again, documenting the simplest option, not the best one).

I've also added Visual Studio Code config folder to .gitignore, it seemed silly to open another PR just for that.

@maximecb Oh, and thanks for creating this project! I started something similar a few years ago - similar vision but smaller scope (no JIT - wonderful to see you adding it).