### PR TITLE
"sdl" as default feature

### DIFF
--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-sdl2 = "0.35.2"
+sdl2 = { version = "0.35.2", optional = true }
 
 [profile.dev]
 debug = true
@@ -24,3 +24,7 @@ lto = true
 # enabled in release mode for security reasons
 overflow-checks = true
 debug-assertions = true
+
+[features]
+sdl = ["dep:sdl2"]
+default = ["sdl"]

--- a/vm/src/main.rs
+++ b/vm/src/main.rs
@@ -7,6 +7,7 @@ mod vm;
 mod sys;
 mod asm;
 
+#[cfg(feature = "sdl")]
 extern crate sdl2;
 use std::env;
 use std::thread::sleep;
@@ -88,6 +89,7 @@ fn run_program(mutex: &mut Arc<Mutex<VM>>) -> Value
     {
         let mut vm = mutex.lock().unwrap();
 
+        #[cfg(feature = "sdl")]
         if let ExitReason::Exit(val) = sys::window::process_events(&mut vm) {
             return val;
         }

--- a/vm/src/sys/audio.rs
+++ b/vm/src/sys/audio.rs
@@ -1,12 +1,11 @@
-#[cfg(feature = "sdl")]
+#![cfg(feature = "sdl")]
+
 use sdl2::audio::{AudioCallback, AudioSpecDesired, AudioDevice};
 use std::sync::{Arc, Weak, Mutex};
 use crate::vm::{Value, VM, ExitReason};
-#[cfg(feature = "sdl")]
 use crate::sys::{get_sdl_context};
 use crate::sys::constants::*;
 
-#[cfg(feature = "sdl")]
 #[derive(Clone)]
 struct AudioCB
 {
@@ -21,7 +20,6 @@ struct AudioCB
     num_channels: usize,
 }
 
-#[cfg(feature = "sdl")]
 impl AudioCallback for AudioCB
 {
     // Signed 16-bit samples
@@ -52,13 +50,11 @@ impl AudioCallback for AudioCB
 /// We have to keep the audio device alive
 /// This is a global variable because it doesn't implement
 /// the Send trait, and so can't be referenced from another thread
-#[cfg(feature = "sdl")]
 static mut DEVICE: Option<AudioDevice<AudioCB>> = None;
 
 // NOTE: this can only be called from the main thread since it uses SDL
 // However, it creates a new thread to generate audio sample, this thread
 // could be given a reference to another VM instance
-#[cfg(feature = "sdl")]
 pub fn audio_open_output(vm: &mut VM, sample_rate: Value, num_channels: Value, format: Value, cb: Value) -> Value
 {
     let sample_rate = sample_rate.as_u32();

--- a/vm/src/sys/audio.rs
+++ b/vm/src/sys/audio.rs
@@ -1,9 +1,12 @@
+#[cfg(feature = "sdl")]
 use sdl2::audio::{AudioCallback, AudioSpecDesired, AudioDevice};
 use std::sync::{Arc, Weak, Mutex};
 use crate::vm::{Value, VM, ExitReason};
+#[cfg(feature = "sdl")]
 use crate::sys::{get_sdl_context};
 use crate::sys::constants::*;
 
+#[cfg(feature = "sdl")]
 #[derive(Clone)]
 struct AudioCB
 {
@@ -18,6 +21,7 @@ struct AudioCB
     num_channels: usize,
 }
 
+#[cfg(feature = "sdl")]
 impl AudioCallback for AudioCB
 {
     // Signed 16-bit samples
@@ -48,11 +52,13 @@ impl AudioCallback for AudioCB
 /// We have to keep the audio device alive
 /// This is a global variable because it doesn't implement
 /// the Send trait, and so can't be referenced from another thread
+#[cfg(feature = "sdl")]
 static mut DEVICE: Option<AudioDevice<AudioCB>> = None;
 
 // NOTE: this can only be called from the main thread since it uses SDL
 // However, it creates a new thread to generate audio sample, this thread
 // could be given a reference to another VM instance
+#[cfg(feature = "sdl")]
 pub fn audio_open_output(vm: &mut VM, sample_rate: Value, num_channels: Value, format: Value, cb: Value) -> Value
 {
     let sample_rate = sample_rate.as_u32();

--- a/vm/src/sys/mod.rs
+++ b/vm/src/sys/mod.rs
@@ -10,7 +10,9 @@ use std::io::Write;
 use std::io::{stdout, stdin};
 use std::sync::{Arc, Weak, Mutex};
 use crate::vm::{Value, VM};
+#[cfg(feature = "sdl")]
 use window::*;
+#[cfg(feature = "sdl")]
 use audio::*;
 use time::*;
 use constants::*;

--- a/vm/src/sys/mod.rs
+++ b/vm/src/sys/mod.rs
@@ -3,6 +3,7 @@ pub mod audio;
 pub mod time;
 pub mod constants;
 
+#[cfg(feature = "sdl")]
 extern crate sdl2;
 use std::collections::HashMap;
 use std::io::Write;
@@ -64,8 +65,10 @@ impl SysCallFn
 /// SDL context (used for UI and audio)
 /// This is a global variable because it doesn't implement
 /// the Send trait, and so can't be referenced from another thread
+#[cfg(feature = "sdl")]
 static mut SDL: Option<sdl2::Sdl> = None;
 
+#[cfg(feature = "sdl")]
 pub fn get_sdl_context() -> &'static mut sdl2::Sdl
 {
     unsafe
@@ -164,16 +167,20 @@ impl SysState
         self.reg_syscall(TIME_CURRENT_MS, SysCallFn::Fn0_1(time_current_ms));
         self.reg_syscall(TIME_DELAY_CB, SysCallFn::Fn2_0(time_delay_cb));
 
-        self.reg_syscall(WINDOW_CREATE, SysCallFn::Fn4_1(window_create));
-        self.reg_syscall(WINDOW_DRAW_FRAME, SysCallFn::Fn2_0(window_draw_frame));
-        self.reg_syscall(WINDOW_ON_MOUSEMOVE, SysCallFn::Fn2_0(window_on_mousemove));
-        self.reg_syscall(WINDOW_ON_MOUSEDOWN, SysCallFn::Fn2_0(window_on_mousedown));
-        self.reg_syscall(WINDOW_ON_MOUSEUP, SysCallFn::Fn2_0(window_on_mouseup));
-        self.reg_syscall(WINDOW_ON_KEYDOWN, SysCallFn::Fn2_0(window_on_keydown));
-        self.reg_syscall(WINDOW_ON_KEYUP, SysCallFn::Fn2_0(window_on_keyup));
-        self.reg_syscall(WINDOW_ON_TEXTINPUT, SysCallFn::Fn2_0(window_on_textinput));
+        #[cfg(feature = "sdl")]
+        {
+            self.reg_syscall(WINDOW_CREATE, SysCallFn::Fn4_1(window_create));
+            self.reg_syscall(WINDOW_DRAW_FRAME, SysCallFn::Fn2_0(window_draw_frame));
+            self.reg_syscall(WINDOW_ON_MOUSEMOVE, SysCallFn::Fn2_0(window_on_mousemove));
+            self.reg_syscall(WINDOW_ON_MOUSEDOWN, SysCallFn::Fn2_0(window_on_mousedown));
+            self.reg_syscall(WINDOW_ON_MOUSEUP, SysCallFn::Fn2_0(window_on_mouseup));
+            self.reg_syscall(WINDOW_ON_KEYDOWN, SysCallFn::Fn2_0(window_on_keydown));
+            self.reg_syscall(WINDOW_ON_KEYUP, SysCallFn::Fn2_0(window_on_keyup));
+            self.reg_syscall(WINDOW_ON_TEXTINPUT, SysCallFn::Fn2_0(window_on_textinput));
 
-        self.reg_syscall(AUDIO_OPEN_OUTPUT, SysCallFn::Fn4_1(audio_open_output));
+            self.reg_syscall(AUDIO_OPEN_OUTPUT, SysCallFn::Fn4_1(audio_open_output));
+        }
+
     }
 }
 

--- a/vm/src/sys/window.rs
+++ b/vm/src/sys/window.rs
@@ -1,26 +1,38 @@
 // Simple display/window device
 
+#[cfg(feature = "sdl")]
 extern crate sdl2;
+#[cfg(feature = "sdl")]
 use sdl2::pixels::Color;
+#[cfg(feature = "sdl")]
 use sdl2::event::Event;
+#[cfg(feature = "sdl")]
 use sdl2::keyboard::Keycode;
+#[cfg(feature = "sdl")]
 use sdl2::mouse::MouseButton;
+#[cfg(feature = "sdl")]
 use sdl2::surface::Surface;
+#[cfg(feature = "sdl")]
 use sdl2::render::Texture;
+#[cfg(feature = "sdl")]
 use sdl2::render::TextureAccess;
+#[cfg(feature = "sdl")]
 use sdl2::pixels::PixelFormatEnum;
 
 use std::time::Duration;
 
+#[cfg(feature = "sdl")]
 use crate::sys::{SysState, get_sdl_context};
 use crate::vm::{VM, Value, ExitReason};
 
 /// SDL video subsystem
 /// This is a global variable because it doesn't implement
 /// the Send trait, and so can't be referenced from another thread
+#[cfg(feature = "sdl")]
 static mut SDL_VIDEO: Option<sdl2::VideoSubsystem> = None;
 
 /// Lazily initialize the SDL video subsystem
+#[cfg(feature = "sdl")]
 fn get_video_subsystem() -> &'static mut sdl2::VideoSubsystem
 {
     unsafe
@@ -35,6 +47,7 @@ fn get_video_subsystem() -> &'static mut sdl2::VideoSubsystem
     }
 }
 
+#[cfg(feature = "sdl")]
 struct Window<'a>
 {
     width: u32,
@@ -60,8 +73,10 @@ struct Window<'a>
 // Note: we're leaving this global to avoid the Window lifetime
 // bubbling up everywhere.
 // TODO: eventually we will likely want to allow multiple windows
+#[cfg(feature = "sdl")]
 static mut WINDOW: Option<Window> = None;
 
+#[cfg(feature = "sdl")]
 fn get_window(window_id: u32) -> &'static mut Window<'static>
 {
     if window_id != 0 {
@@ -73,6 +88,7 @@ fn get_window(window_id: u32) -> &'static mut Window<'static>
     }
 }
 
+#[cfg(feature = "sdl")]
 pub fn window_create(vm: &mut VM, width: Value, height: Value, title: Value, flags: Value) -> Value
 {
     unsafe {
@@ -124,6 +140,7 @@ pub fn window_create(vm: &mut VM, width: Value, height: Value, title: Value, fla
     Value::from(0)
 }
 
+#[cfg(feature = "sdl")]
 pub fn window_draw_frame(vm: &mut VM, window_id: Value, src_addr: Value)
 {
     // Get the address to copy pixel data from
@@ -165,36 +182,42 @@ pub fn window_draw_frame(vm: &mut VM, window_id: Value, src_addr: Value)
     window.canvas.present();
 }
 
+#[cfg(feature = "sdl")]
 pub fn window_on_mousemove(vm: &mut VM, window_id: Value, cb: Value)
 {
     let window = get_window(window_id.as_u32());
     window.cb_mousemove = cb.as_u64();
 }
 
+#[cfg(feature = "sdl")]
 pub fn window_on_mousedown(vm: &mut VM, window_id: Value, cb: Value)
 {
     let window = get_window(window_id.as_u32());
     window.cb_mousedown = cb.as_u64();
 }
 
+#[cfg(feature = "sdl")]
 pub fn window_on_mouseup(vm: &mut VM, window_id: Value, cb: Value)
 {
     let window = get_window(window_id.as_u32());
     window.cb_mouseup = cb.as_u64();
 }
 
+#[cfg(feature = "sdl")]
 pub fn window_on_keydown(vm: &mut VM, window_id: Value, cb: Value)
 {
     let window = get_window(window_id.as_u32());
     window.cb_keydown = cb.as_u64();
 }
 
+#[cfg(feature = "sdl")]
 pub fn window_on_keyup(vm: &mut VM, window_id: Value, cb: Value)
 {
     let window = get_window(window_id.as_u32());
     window.cb_keyup = cb.as_u64();
 }
 
+#[cfg(feature = "sdl")]
 pub fn window_on_textinput(vm: &mut VM, window_id: Value, cb: Value)
 {
     let window = get_window(window_id.as_u32());
@@ -204,6 +227,7 @@ pub fn window_on_textinput(vm: &mut VM, window_id: Value, cb: Value)
 }
 
 /// Process SDL events
+#[cfg(feature = "sdl")]
 pub fn process_events(vm: &mut VM) -> ExitReason
 {
     let mut event_pump = get_sdl_context().event_pump().unwrap();
@@ -270,6 +294,7 @@ pub fn process_events(vm: &mut VM) -> ExitReason
 
 // TODO: this is just for testing
 // we should handle window-related events here instead
+#[cfg(feature = "sdl")]
 fn window_call_mousemove(vm: &mut VM, window_id: u32, x: i32, y: i32) -> ExitReason
 {
     let window = get_window(0);
@@ -292,6 +317,7 @@ MouseButtonDown {
     y: i32,
 },
 */
+#[cfg(feature = "sdl")]
 fn window_call_mousedown(vm: &mut VM, window_id: u32, mouse_id: u32, mouse_btn: MouseButton) -> ExitReason
 {
     let window = get_window(0);
@@ -320,6 +346,7 @@ fn window_call_mousedown(vm: &mut VM, window_id: u32, mouse_id: u32, mouse_btn: 
     vm.call(cb, &[Value::from(window.window_id), Value::from(btn_id)])
 }
 
+#[cfg(feature = "sdl")]
 fn window_call_mouseup(vm: &mut VM, window_id: u32, mouse_id: u32, mouse_btn: MouseButton) -> ExitReason
 {
     let window = get_window(0);
@@ -348,6 +375,7 @@ fn window_call_mouseup(vm: &mut VM, window_id: u32, mouse_id: u32, mouse_btn: Mo
     vm.call(cb, &[Value::from(window.window_id), Value::from(btn_id)])
 }
 
+#[cfg(feature = "sdl")]
 fn translate_keycode(sdl_keycode: Keycode) -> Option<u16>
 {
     use crate::sys::constants::*;
@@ -416,6 +444,7 @@ fn translate_keycode(sdl_keycode: Keycode) -> Option<u16>
     }
 }
 
+#[cfg(feature = "sdl")]
 fn window_call_keydown(vm: &mut VM, window_id: u32, keycode: Keycode) -> ExitReason
 {
     let window = get_window(0);
@@ -434,6 +463,7 @@ fn window_call_keydown(vm: &mut VM, window_id: u32, keycode: Keycode) -> ExitRea
     }
 }
 
+#[cfg(feature = "sdl")]
 fn window_call_keyup(vm: &mut VM, window_id: u32, keycode: Keycode) -> ExitReason
 {
     let window = get_window(0);
@@ -452,6 +482,7 @@ fn window_call_keyup(vm: &mut VM, window_id: u32, keycode: Keycode) -> ExitReaso
     }
 }
 
+#[cfg(feature = "sdl")]
 fn window_call_textinput(vm: &mut VM, window_id: u32, utf8_byte: u8) -> ExitReason
 {
     let window = get_window(0);

--- a/vm/src/sys/window.rs
+++ b/vm/src/sys/window.rs
@@ -1,38 +1,28 @@
 // Simple display/window device
 
-#[cfg(feature = "sdl")]
+#![cfg(feature = "sdl")]
+
 extern crate sdl2;
-#[cfg(feature = "sdl")]
 use sdl2::pixels::Color;
-#[cfg(feature = "sdl")]
 use sdl2::event::Event;
-#[cfg(feature = "sdl")]
 use sdl2::keyboard::Keycode;
-#[cfg(feature = "sdl")]
 use sdl2::mouse::MouseButton;
-#[cfg(feature = "sdl")]
 use sdl2::surface::Surface;
-#[cfg(feature = "sdl")]
 use sdl2::render::Texture;
-#[cfg(feature = "sdl")]
 use sdl2::render::TextureAccess;
-#[cfg(feature = "sdl")]
 use sdl2::pixels::PixelFormatEnum;
 
 use std::time::Duration;
 
-#[cfg(feature = "sdl")]
 use crate::sys::{SysState, get_sdl_context};
 use crate::vm::{VM, Value, ExitReason};
 
 /// SDL video subsystem
 /// This is a global variable because it doesn't implement
 /// the Send trait, and so can't be referenced from another thread
-#[cfg(feature = "sdl")]
 static mut SDL_VIDEO: Option<sdl2::VideoSubsystem> = None;
 
 /// Lazily initialize the SDL video subsystem
-#[cfg(feature = "sdl")]
 fn get_video_subsystem() -> &'static mut sdl2::VideoSubsystem
 {
     unsafe
@@ -47,7 +37,6 @@ fn get_video_subsystem() -> &'static mut sdl2::VideoSubsystem
     }
 }
 
-#[cfg(feature = "sdl")]
 struct Window<'a>
 {
     width: u32,
@@ -73,10 +62,8 @@ struct Window<'a>
 // Note: we're leaving this global to avoid the Window lifetime
 // bubbling up everywhere.
 // TODO: eventually we will likely want to allow multiple windows
-#[cfg(feature = "sdl")]
 static mut WINDOW: Option<Window> = None;
 
-#[cfg(feature = "sdl")]
 fn get_window(window_id: u32) -> &'static mut Window<'static>
 {
     if window_id != 0 {
@@ -88,7 +75,6 @@ fn get_window(window_id: u32) -> &'static mut Window<'static>
     }
 }
 
-#[cfg(feature = "sdl")]
 pub fn window_create(vm: &mut VM, width: Value, height: Value, title: Value, flags: Value) -> Value
 {
     unsafe {
@@ -140,7 +126,6 @@ pub fn window_create(vm: &mut VM, width: Value, height: Value, title: Value, fla
     Value::from(0)
 }
 
-#[cfg(feature = "sdl")]
 pub fn window_draw_frame(vm: &mut VM, window_id: Value, src_addr: Value)
 {
     // Get the address to copy pixel data from
@@ -182,42 +167,36 @@ pub fn window_draw_frame(vm: &mut VM, window_id: Value, src_addr: Value)
     window.canvas.present();
 }
 
-#[cfg(feature = "sdl")]
 pub fn window_on_mousemove(vm: &mut VM, window_id: Value, cb: Value)
 {
     let window = get_window(window_id.as_u32());
     window.cb_mousemove = cb.as_u64();
 }
 
-#[cfg(feature = "sdl")]
 pub fn window_on_mousedown(vm: &mut VM, window_id: Value, cb: Value)
 {
     let window = get_window(window_id.as_u32());
     window.cb_mousedown = cb.as_u64();
 }
 
-#[cfg(feature = "sdl")]
 pub fn window_on_mouseup(vm: &mut VM, window_id: Value, cb: Value)
 {
     let window = get_window(window_id.as_u32());
     window.cb_mouseup = cb.as_u64();
 }
 
-#[cfg(feature = "sdl")]
 pub fn window_on_keydown(vm: &mut VM, window_id: Value, cb: Value)
 {
     let window = get_window(window_id.as_u32());
     window.cb_keydown = cb.as_u64();
 }
 
-#[cfg(feature = "sdl")]
 pub fn window_on_keyup(vm: &mut VM, window_id: Value, cb: Value)
 {
     let window = get_window(window_id.as_u32());
     window.cb_keyup = cb.as_u64();
 }
 
-#[cfg(feature = "sdl")]
 pub fn window_on_textinput(vm: &mut VM, window_id: Value, cb: Value)
 {
     let window = get_window(window_id.as_u32());
@@ -227,7 +206,6 @@ pub fn window_on_textinput(vm: &mut VM, window_id: Value, cb: Value)
 }
 
 /// Process SDL events
-#[cfg(feature = "sdl")]
 pub fn process_events(vm: &mut VM) -> ExitReason
 {
     let mut event_pump = get_sdl_context().event_pump().unwrap();
@@ -294,7 +272,6 @@ pub fn process_events(vm: &mut VM) -> ExitReason
 
 // TODO: this is just for testing
 // we should handle window-related events here instead
-#[cfg(feature = "sdl")]
 fn window_call_mousemove(vm: &mut VM, window_id: u32, x: i32, y: i32) -> ExitReason
 {
     let window = get_window(0);
@@ -317,7 +294,6 @@ MouseButtonDown {
     y: i32,
 },
 */
-#[cfg(feature = "sdl")]
 fn window_call_mousedown(vm: &mut VM, window_id: u32, mouse_id: u32, mouse_btn: MouseButton) -> ExitReason
 {
     let window = get_window(0);
@@ -346,7 +322,6 @@ fn window_call_mousedown(vm: &mut VM, window_id: u32, mouse_id: u32, mouse_btn: 
     vm.call(cb, &[Value::from(window.window_id), Value::from(btn_id)])
 }
 
-#[cfg(feature = "sdl")]
 fn window_call_mouseup(vm: &mut VM, window_id: u32, mouse_id: u32, mouse_btn: MouseButton) -> ExitReason
 {
     let window = get_window(0);
@@ -375,7 +350,6 @@ fn window_call_mouseup(vm: &mut VM, window_id: u32, mouse_id: u32, mouse_btn: Mo
     vm.call(cb, &[Value::from(window.window_id), Value::from(btn_id)])
 }
 
-#[cfg(feature = "sdl")]
 fn translate_keycode(sdl_keycode: Keycode) -> Option<u16>
 {
     use crate::sys::constants::*;
@@ -444,7 +418,6 @@ fn translate_keycode(sdl_keycode: Keycode) -> Option<u16>
     }
 }
 
-#[cfg(feature = "sdl")]
 fn window_call_keydown(vm: &mut VM, window_id: u32, keycode: Keycode) -> ExitReason
 {
     let window = get_window(0);
@@ -463,7 +436,6 @@ fn window_call_keydown(vm: &mut VM, window_id: u32, keycode: Keycode) -> ExitRea
     }
 }
 
-#[cfg(feature = "sdl")]
 fn window_call_keyup(vm: &mut VM, window_id: u32, keycode: Keycode) -> ExitReason
 {
     let window = get_window(0);
@@ -482,7 +454,6 @@ fn window_call_keyup(vm: &mut VM, window_id: u32, keycode: Keycode) -> ExitReaso
     }
 }
 
-#[cfg(feature = "sdl")]
 fn window_call_textinput(vm: &mut VM, window_id: u32, utf8_byte: u8) -> ExitReason
 {
     let window = get_window(0);


### PR DESCRIPTION
I implemented "sdl" as a default feature, to compile the vm as headless use

```cargo build --no-default-features```

This is required as features in rust are supposed to add features (and not remove them).

Things are a bit ugly as the #[cfg] directive can only conditionally compile ranges of code inside a function, so for example in

vm/src/sys.mod

 I can do
```rust
        #[cfg(feature = "sdl")]
        {
            self.reg_syscall(WINDOW_CREATE, SysCallFn::Fn4_1(window_create));
            self.reg_syscall(WINDOW_DRAW_FRAME, SysCallFn::Fn2_0(window_draw_frame));
            self.reg_syscall(WINDOW_ON_MOUSEMOVE, SysCallFn::Fn2_0(window_on_mousemove));
            self.reg_syscall(WINDOW_ON_MOUSEDOWN, SysCallFn::Fn2_0(window_on_mousedown));
            self.reg_syscall(WINDOW_ON_MOUSEUP, SysCallFn::Fn2_0(window_on_mouseup));
            self.reg_syscall(WINDOW_ON_KEYDOWN, SysCallFn::Fn2_0(window_on_keydown));
            self.reg_syscall(WINDOW_ON_KEYUP, SysCallFn::Fn2_0(window_on_keyup));
            self.reg_syscall(WINDOW_ON_TEXTINPUT, SysCallFn::Fn2_0(window_on_textinput));

            self.reg_syscall(AUDIO_OPEN_OUTPUT, SysCallFn::Fn4_1(audio_open_output));
        }
```

However as I cannot do this at the top level of files, so I needed to add a lot of ```#[cfg(feature = "sdl")]``` to sys/window.rs (and there is no way around this).

In headless mode I could compile and run the ```hello_world.c``` ncc example, while ```snake.c``` would obviously fail with an unknown syscall.
